### PR TITLE
Release 1.0.1

### DIFF
--- a/include/pybind11_ext/boost/circular_buffer.hpp
+++ b/include/pybind11_ext/boost/circular_buffer.hpp
@@ -57,6 +57,8 @@ class numpy_circular_buffer : public boost::circular_buffer<T, allocator<T>>
 public:
     explicit numpy_circular_buffer(size_t capacity);
 
+    numpy_circular_buffer(const numpy_circular_buffer& other) = delete;
+
     template <typename V = T>
     pybind11::readonly_memoryview to_memoryview(ptrdiff_t offset = 0u);
 

--- a/include/pybind11_ext/boost/circular_buffer.ipp
+++ b/include/pybind11_ext/boost/circular_buffer.ipp
@@ -92,7 +92,7 @@ inline pointer_type allocated_block::pointer()
     return reinterpret_cast<pointer_type>(first_map_);
 }
 
-std::string allocated_block::generate_shm_key()
+inline std::string allocated_block::generate_shm_key()
 {
     auto temp = boost::filesystem::unique_path();
     return temp.native();
@@ -108,7 +108,7 @@ inline typename allocator<element_type>::pointer_type allocator<element_type>::a
 }
 
 template <typename element_type>
-void allocator<element_type>::deallocate(allocator::pointer_type p, size_t n)
+inline void allocator<element_type>::deallocate(allocator::pointer_type p, size_t n)
 {
     allocated_blocks_.remove_if([&](allocated_block& tested) { return tested.template pointer<pointer_type>() == p; });
 }


### PR DESCRIPTION
[issue-5](https://github.com/lukaszlaszko/pybind11_ext/issues/5) - circular_buffer - some of the header methods not marked as inline